### PR TITLE
Support bearer token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,20 @@ To use kubectl put this step into your workflow:
 - uses: actions-hub/kubectl@master
   env:
     KUBE_HOST: ${{ secrets.KUBE_HOST }}
+    KUBE_CERTIFICATE: ${{ secrets.KUBE_CERTIFICATE }}
     KUBE_USERNAME: ${{ secrets.KUBE_USERNAME }}
     KUBE_PASSWORD: ${{ secrets.KUBE_PASSWORD }}
+  with:
+    args: get pods
+```
+
+### Authorization with a bearer token
+```yaml
+- uses: actions-hub/kubectl@master
+  env:
+    KUBE_HOST: ${{ secrets.KUBE_HOST }}
     KUBE_CERTIFICATE: ${{ secrets.KUBE_CERTIFICATE }}
+    KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
   with:
     args: get pods
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ if [ ! -f "$HOME/.kube/config" ]; then
         kubectl config use-context default > /dev/null
 
     else
-        echo "No authorization data found. Please provide CONFIG or HTTPS variables. Exiting...."
+        echo "No authorization data found. Please provide KUBE_CONFIG or KUBE_HOST variables. Exiting..."
         exit 1
     fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,16 @@ if [ ! -f "$HOME/.kube/config" ]; then
 
         echo "$KUBE_CERTIFICATE" | base64 -d > $HOME/.kube/certificate
         kubectl config set-cluster default --server=https://$KUBE_HOST --certificate-authority=$HOME/.kube/certificate > /dev/null
-        kubectl config set-credentials cluster-admin --username=$KUBE_USERNAME --password=$KUBE_PASSWORD > /dev/null
+
+        if [ ! -z "${KUBE_PASSWORD}" ]; then
+            kubectl config set-credentials cluster-admin --username=$KUBE_USERNAME --password=$KUBE_PASSWORD > /dev/null
+        elif [ ! -z "${KUBE_TOKEN}" ]; then
+            kubectl config set-credentials cluster-admin --token="${KUBE_TOKEN}" > /dev/null
+        else
+            echo "No credentials found. Please provide KUBE_TOKEN, or KUBE_USERNAME and KUBE_PASSWORD. Exiting..."
+            exit 1
+        fi
+
         kubectl config set-context default --cluster=default --namespace=default --user=cluster-admin > /dev/null
         kubectl config use-context default > /dev/null
 


### PR DESCRIPTION
This updates the action to support `$KUBE_TOKEN` instead of `$KUBE_USERNAME` and `$KUBE_PASSWORD`.