### PR TITLE
Upgrade latest Alpine release and switch the mirror to Yandex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10.2
+FROM alpine:3.14.2
 MAINTAINER Serhiy Mitrovtsiy <mitrovtsiy@ukr.net>
 
 ARG KUBE_VERSION="1.21.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ARG KUBE_VERSION="1.21.2"
 
 COPY entrypoint.sh /entrypoint.sh
 
+RUN sed -i 's/https\:\/\/dl-cdn.alpinelinux.org/https\:\/\/mirror.yandex.ru\/mirrors\//g' /etc/apk/repositories
+
 RUN chmod +x /entrypoint.sh && \
     apk add --no-cache --update openssl curl ca-certificates && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \


### PR DESCRIPTION
Don't know why all my servers cannot fetch the below files (step 5/7, command ```apk add --no-cache --update...```) led to hang of Actions. After I changed the mirror to Yandex, all timeout is gone and the container can build again.

https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
https://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz