### PR TITLE
Overwrite kube config if set as env var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,36 +6,34 @@ if [ ! -d "$HOME/.kube" ]; then
     mkdir -p $HOME/.kube
 fi
 
-if [ ! -f "$HOME/.kube/config" ]; then
-    if [ ! -z "${KUBE_CONFIG}" ]; then
+if [ ! -z "${KUBE_CONFIG}" ]; then
 
-        echo "$KUBE_CONFIG" | base64 -d > $HOME/.kube/config
+    echo "$KUBE_CONFIG" | base64 -d > $HOME/.kube/config
 
-        if [ ! -z "${KUBE_CONTEXT}" ]; then
-            kubectl config use-context $KUBE_CONTEXT
-        fi
+    if [ ! -z "${KUBE_CONTEXT}" ]; then
+        kubectl config use-context $KUBE_CONTEXT
+    fi
 
-    elif [ ! -z "${KUBE_HOST}" ]; then
+elif [ ! -z "${KUBE_HOST}" ]; then
 
-        echo "$KUBE_CERTIFICATE" | base64 -d > $HOME/.kube/certificate
-        kubectl config set-cluster default --server=https://$KUBE_HOST --certificate-authority=$HOME/.kube/certificate > /dev/null
+    echo "$KUBE_CERTIFICATE" | base64 -d > $HOME/.kube/certificate
+    kubectl config set-cluster default --server=https://$KUBE_HOST --certificate-authority=$HOME/.kube/certificate > /dev/null
 
-        if [ ! -z "${KUBE_PASSWORD}" ]; then
-            kubectl config set-credentials cluster-admin --username=$KUBE_USERNAME --password=$KUBE_PASSWORD > /dev/null
-        elif [ ! -z "${KUBE_TOKEN}" ]; then
-            kubectl config set-credentials cluster-admin --token="${KUBE_TOKEN}" > /dev/null
-        else
-            echo "No credentials found. Please provide KUBE_TOKEN, or KUBE_USERNAME and KUBE_PASSWORD. Exiting..."
-            exit 1
-        fi
-
-        kubectl config set-context default --cluster=default --namespace=default --user=cluster-admin > /dev/null
-        kubectl config use-context default > /dev/null
-
+    if [ ! -z "${KUBE_PASSWORD}" ]; then
+        kubectl config set-credentials cluster-admin --username=$KUBE_USERNAME --password=$KUBE_PASSWORD > /dev/null
+    elif [ ! -z "${KUBE_TOKEN}" ]; then
+        kubectl config set-credentials cluster-admin --token="${KUBE_TOKEN}" > /dev/null
     else
-        echo "No authorization data found. Please provide KUBE_CONFIG or KUBE_HOST variables. Exiting..."
+        echo "No credentials found. Please provide KUBE_TOKEN, or KUBE_USERNAME and KUBE_PASSWORD. Exiting..."
         exit 1
     fi
+
+    kubectl config set-context default --cluster=default --namespace=default --user=cluster-admin > /dev/null
+    kubectl config use-context default > /dev/null
+
+if [ ! -f "$HOME/.kube/config" ]; then
+    echo "No authorization data found. Please provide KUBE_CONFIG or KUBE_HOST variables. Exiting..."
+    exit 1
 fi
 
 echo "/usr/local/bin/kubectl" >> $GITHUB_PATH

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ elif [ ! -z "${KUBE_HOST}" ]; then
     kubectl config set-context default --cluster=default --namespace=default --user=cluster-admin > /dev/null
     kubectl config use-context default > /dev/null
 
-if [ ! -f "$HOME/.kube/config" ]; then
+elif [ ! -f "$HOME/.kube/config" ]; then
     echo "No authorization data found. Please provide KUBE_CONFIG or KUBE_HOST variables. Exiting..."
     exit 1
 fi


### PR DESCRIPTION
I had a problem running the kubectl action when using multiple environments running on their own cluster. Once set the kube config didn't change anymore even though I set a new one through `KUBE_CONFIG`.
Therefore, always overwrite the kube config if a new one is set through env vars.