### PR TITLE
Redirect output to variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,11 @@ inputs:
   args:
     description: 'Arguments for the CLI command'
     required: false
+  redirect-to:
+    description: 'Variable name to redirect CLI output'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  env:
+    dest: ${{ inputs.redirect-to }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,6 +42,7 @@ if [ -z "$dest" ]; then
 else
     output=$(kubectl $*)
     echo "::set-output name=$dest::$output"
+    echo "::add-mask::$output"
 
     # debug only
     #echo $output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,10 +40,9 @@ fi
 if [ -z "$dest" ]; then
     kubectl $*
 else
-    output=$(kubectl $*)
-    echo "::set-output name=$dest::$output"
-    echo "::add-mask::$output"
-
-    # debug only
-    #echo $output
+    echo "$dest<<EOF" >> $GITHUB_ENV
+    kubectl $* >> $GITHUB_ENV
+    echo "EOF" >> $GITHUB_ENV
+    
+    echo "::add-mask::$dest"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,4 +37,12 @@ if [ ! -f "$HOME/.kube/config" ]; then
     fi
 fi
 
-kubectl $*
+if [ -z "$dest" ]; then
+    kubectl $*
+else
+    output=$(kubectl $*)
+    echo "::set-output name=$dest::$output"
+
+    # debug only
+    #echo $output
+fi


### PR DESCRIPTION
I had a same issue with #13
So I added a new arg `redirect-to` as below.
If this variable is set, the `kubectl` command output will be redirected to variable.

```yaml
- uses: skyducks/kubectl@master
  id: kubectl-get-pod
  with:
    args: get pod --no-headers --selector=app=your-deployment -o custom-columns=":metadata.name"
    redirect-to: name
- run: echo ${{ steps.kubectl-get-pod.outputs.name }}
```