### PR TITLE
fix: ensure a newline is inserted before delimiter

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,9 +40,13 @@ fi
 if [ -z "$dest" ]; then
     kubectl $*
 else
-    echo "$dest<<EOF" >> $GITHUB_ENV
+    EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+    echo "$dest<<$EOF" >> $GITHUB_ENV
     kubectl $* >> $GITHUB_ENV
-    echo "EOF" >> $GITHUB_ENV
-    
+    if [[ "${GITHUB_ENV: -1}" != $'\n' ]]; then
+        echo >> $GITHUB_ENV
+    fi
+    echo "$EOF" >> $GITHUB_ENV
+
     echo "::add-mask::$dest"
 fi


### PR DESCRIPTION
This PR addresses two issues with the existing output redirect functionality:

1. In the current implementation, if the kubectl output (`kubectl $*`) does not end with a newline, the action fails. This is because the delimiter (`EOF`) is inserted on the same line as the output. This PR ensures that a newline is always added before the end delimiter to prevent this issue.

2. The current multiline delimiter is a literal `EOF`, which does not adhere to the recommendations in [the official documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings). This PR replaces the literal `EOF` with a randomly generated delimiter, following the [example provided in the official documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string).