### PR TITLE
Entrypoint: support updating credentials

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,33 +8,31 @@ if [ ! -d "$HOME/.kube" ]; then
     mkdir -p $HOME/.kube
 fi
 
-if [ ! -f "$HOME/.kube/config" ]; then
-    if [ ! -z "${KUBE_CONFIG}" ]; then
-        echo "$KUBE_CONFIG" | base64 -d > $HOME/.kube/config
+if [ ! -z "${KUBE_CONFIG}" ]; then
+    echo "$KUBE_CONFIG" | base64 -d > $HOME/.kube/config
 
-        if [ ! -z "${KUBE_CONTEXT}" ]; then
-            kubectl config use-context $KUBE_CONTEXT
-        fi
-    elif [ ! -z "${KUBE_HOST}" ]; then
-        echo "$KUBE_CERTIFICATE" | base64 -d > $HOME/.kube/certificate
-        kubectl config set-cluster default --server=https://$KUBE_HOST --certificate-authority=$HOME/.kube/certificate > /dev/null
+    if [ ! -z "${KUBE_CONTEXT}" ]; then
+        kubectl config use-context $KUBE_CONTEXT
+    fi
+elif [ ! -z "${KUBE_HOST}" ]; then
+    echo "$KUBE_CERTIFICATE" | base64 -d > $HOME/.kube/certificate
+    kubectl config set-cluster default --server=https://$KUBE_HOST --certificate-authority=$HOME/.kube/certificate > /dev/null
 
-        if [ ! -z "${KUBE_PASSWORD}" ]; then
-            kubectl config set-credentials cluster-admin --username=$KUBE_USERNAME --password=$KUBE_PASSWORD > /dev/null
-        elif [ ! -z "${KUBE_TOKEN}" ]; then
-            kubectl config set-credentials cluster-admin --token="${KUBE_TOKEN}" > /dev/null
-        else
-            echo "No credentials found. Please provide KUBE_TOKEN, or KUBE_USERNAME and KUBE_PASSWORD. Exiting..."
-            exit 1
-        fi
-
-        kubectl config set-context default --cluster=default --namespace=default --user=cluster-admin > /dev/null
-        kubectl config use-context default > /dev/null
-    elif [[ $* == "kustomize" ]]; then :;
+    if [ ! -z "${KUBE_PASSWORD}" ]; then
+        kubectl config set-credentials cluster-admin --username=$KUBE_USERNAME --password=$KUBE_PASSWORD > /dev/null
+    elif [ ! -z "${KUBE_TOKEN}" ]; then
+        kubectl config set-credentials cluster-admin --token="${KUBE_TOKEN}" > /dev/null
     else
-        echo "No authorization data found. Please provide KUBE_CONFIG or KUBE_HOST variables. Exiting..."
+        echo "No credentials found. Please provide KUBE_TOKEN, or KUBE_USERNAME and KUBE_PASSWORD. Exiting..."
         exit 1
     fi
+
+    kubectl config set-context default --cluster=default --namespace=default --user=cluster-admin > /dev/null
+    kubectl config use-context default > /dev/null
+elif [[ $* == "kustomize" ]]; then :;
+else
+    echo "No authorization data found. Please provide KUBE_CONFIG or KUBE_HOST variables. Exiting..."
+    exit 1
 fi
 
 if [ -z "$dest" ]; then


### PR DESCRIPTION
The entrypoint.sh script will only attempt to apply the contents of the `KUBE_CONFIG` variable when ~/.kube/config doesn't exist, which means if the credentials in the KUBE_CONFIG variable changes the image is stuck with the old ones, rendering the action useless when organization secrets change.

This patch removes the requirement for environment variables to be applied only when ~/.kube/config doesn't exist. 

The environment variables are passed every run, they should be regarded every run.