### PR TITLE
Update Dockerfile to support arm, arm64 and amd64 architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM alpine:3.17
 MAINTAINER Serhiy Mitrovtsiy <mitrovtsiy@ukr.net>
 
+ARG TARGETPLATFORM
 ARG KUBE_VERSION="v1.29.2"
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /entrypoint.sh && \
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=arm; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi && \
+    chmod +x /entrypoint.sh && \
     apk add --no-cache --update openssl curl ca-certificates && \
-    curl -L https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
+    curl -L https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$ARCHITECTURE/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
I run a k8s cluster on a 4 node aarch setup. As-is, this action does not support ARM or ARM64/aarch64, resulting in:
```bash
Run actions-hub/kubectl@v1.29.1
/usr/bin/docker run --name b18dcd0bd6e6295bf045a091e5e745560b394b_d36f21 --label b18dcd --workdir /github/workspace [...] "/home/runner/_work/github-actions-test/github-actions-test":"/github/workspace" b18dcd:0bd6e6295bf045a091e5e745560b394b get pods
/usr/local/bin/kubectl: line 1: syntax error: unexpected "("
```

Accounting for architecture in the dockerfile fixes the problem.