### PR TITLE
Fix redirect-to argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ jobs:
           args: get pods
 ```
 
+## Access output in other steps
+
+If you want to use the output of the kubectl command in another step, you can use the `redirect-to` option. 
+```yaml
+- uses: actions-hub/kubectl@master
+  id: get-pods
+  env:
+    KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+  with:
+    args: get pods
+    redirect-to: pods
+```
+
+The output can then be accessed in another step like this:
+```yaml
+- run: echo "${{ steps.get-pods.outputs.pods }}"
+```
+
 ## Versions
 If you need a specific version of kubectl, make a PR with a specific version number.
 After accepting PR the new release will be created.   

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,9 +40,13 @@ fi
 if [ -z "$dest" ]; then
     kubectl $*
 else
-    echo "$dest<<EOF" >> $GITHUB_ENV
-    kubectl $* >> $GITHUB_ENV
-    echo "EOF" >> $GITHUB_ENV
-    
-    echo "::add-mask::$dest"
+    output=$(kubectl $*)
+    if [ $(echo "$output" | wc -l) == 1 ]; then
+        echo "$dest=$output" >> $GITHUB_OUTPUT
+        echo "::add-mask::$output"
+    else
+        echo "$dest<<EOF" >> $GITHUB_OUTPUT
+        echo "$output" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+    fi
 fi


### PR DESCRIPTION
fixes: #27 

## Problems

Currently the `redirect-to` argument only works when the output is multi-lined, is only a single line output is provided an error occurs.

## Solution

Implement the suggestion of @skyducks in PR #14  and updates the outputs to use `$GITHUB_OUTPUT`.
Additionally I added some documentation about `redirect-to` so that user are aware of its existance.

## Testing

- [x] Tested against a single line output (No longer throws and error)
- [x] Tested against multi-line output (Still works as expected) 